### PR TITLE
A tool for converting spark-sumbit start-job-run

### DIFF
--- a/tools/start-job-run-converter/README.md
+++ b/tools/start-job-run-converter/README.md
@@ -1,0 +1,214 @@
+# start-job-run converter
+This tool can be used to migrate spark-submit commands in a script to **aws emr-containers start-job-run**
+and save the result to a new file with _converted suffix.
+
+Supported arguments:
+```
+  -h, --help            show this help message and exit
+  --file FILE           the input spark-submit script file
+  --name NAME           The name of the job run
+  --virtual-cluster-id VIRTUAL_CLUSTER_ID
+                        The virtual cluster ID for which the job run request is submitted
+  --client-token CLIENT_TOKEN
+                        The client idempotency token of the job run request
+  --execution-role-arn EXECUTION_ROLE_ARN
+                        The execution role ARN for the job run
+  --release-label RELEASE_LABEL
+                        The Amazon EMR release version to use for the job run
+  --configuration-overrides CONFIGURATION_OVERRIDES
+                        The configuration overrides for the job run
+  --tags TAGS           The tags assigned to job runs
+```
+
+##Run the tool
+
+```
+startJobRunConverter.py \
+--file ./submit_script.sh \
+--virtual-cluster-id <virtual-cluster-id> \
+--name emreks-test-job \
+--execution-role-arn <execution-role-arn> \
+--release-label emr-6.4.0-latest \
+--tags KeyName1=string \
+--configuration-overrides '{
+  "monitoringConfiguration": {
+    "cloudWatchMonitoringConfiguration": {
+      "logGroupName": "emrekstest",
+      "logStreamNamePrefix": "emreks_log_stream"
+    },
+    "s3MonitoringConfiguration": {
+       "logUri": "s3://<s3 log bucket>"
+    }
+  }
+}'
+```
+
+###Example 1
+Below spark-submit command in submit_script.sh
+```
+spark-submit --deploy-mode cluster \
+--conf spark.executor.instances=2 \
+--conf spark.executor.memory=2G \
+--conf spark.executor.cores=2 \
+--conf spark.driver.cores=1 \
+--conf "spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps" \
+--verbose \
+s3://<s3 bucket>/health_violations.py \
+--data_source s3://<s3 bucket>/food_establishment_data.csv \
+--output_uri s3://<s3 bucket>/myOutputFolder
+```
+
+is converted to below in submit_script.sh_converted
+
+```
+#spark-submit --deploy-mode cluster \
+#--conf spark.executor.instances=2 \
+#--conf spark.executor.memory=2G \
+#--conf spark.executor.cores=2 \
+#--conf spark.driver.cores=1 \
+#--conf "spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps" \
+#--verbose \
+#s3://<s3 bucket>/health_violations.py \
+#--data_source s3://<s3 bucket>/food_establishment_data.csv \
+#--output_uri s3://<s3 bucket>/myOutputFolder
+
+# ----- Auto converted by startJobRunConverter.py -----
+aws emr-containers start-job-run \
+--name emreks-test-job \
+--virtual-cluster-id <virtual-cluster-id> \
+--execution-role-arn <execution-role-arn> \
+--release-label emr-6.4.0-latest \
+--configuration-overrides '{
+  "monitoringConfiguration": {
+    "cloudWatchMonitoringConfiguration": {
+      "logGroupName": "emrekstest",
+      "logStreamNamePrefix": "emreks_log_stream"
+    },
+    "s3MonitoringConfiguration": {
+       "logUri": "s3://<s3 log bucket>"
+    }
+  }
+}' \
+--tags KeyName1=string \
+--job-driver '{
+    "sparkSubmitJobDriver": {
+        "entryPoint": "s3://<s3 bucket>/health_violations.py",
+        "entryPointArguments": [
+            "--data_source",
+            "s3://<s3 bucket>/food_establishment_data.csv",
+            "--output_uri",
+            "s3://<s3 bucket>/myOutputFolder"
+        ],
+        "sparkSubmitParameters": "--deploy-mode cluster --conf spark.executor.instances=2 --conf spark.executor.memory=2G --conf spark.executor.cores=2 --conf spark.driver.cores=1 --conf \"spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps\" --verbose"
+    }
+}'
+```
+>As you can see in the example, the original spark-submit command is kept as comments
+
+###Example 2
+```
+EXECMEM=2G
+EXEC_INST=2
+REGION=us-east-2
+spark-submit --deploy-mode cluster \
+--conf spark.executor.instances=$EXEC_INST --conf spark.executor.memory=$EXECMEM --conf spark.executor.cores=2 --conf spark.driver.cores=1 \
+s3://<s3 bucket>/wordcount.py s3://<s3 bucket>/wordcount_output $REGION
+```
+
+is converted to below in submit_script.sh_converted
+
+```
+
+EXECMEM=2G
+EXEC_INST=2
+REGION=us-east-2
+#spark-submit --deploy-mode cluster \
+#--conf spark.executor.instances=$EXEC_INST --conf spark.executor.memory=$EXECMEM --conf spark.executor.cores=2 --conf spark.driver.cores=1 \
+#s3://<s3 bucket>/wordcount.py s3://<s3 bucket>/wordcount_output $REGION
+
+# ----- Auto converted by startJobRunConverter.py -----
+aws emr-containers start-job-run \
+--name emreks-test-job \
+--virtual-cluster-id <virtual-cluster-id> \
+--execution-role-arn <execution-role-arn> \
+--release-label emr-6.4.0-latest \
+--configuration-overrides '{
+  "monitoringConfiguration": {
+    "cloudWatchMonitoringConfiguration": {
+      "logGroupName": "emrekstest",
+      "logStreamNamePrefix": "emreks_log_stream"
+    },
+    "s3MonitoringConfiguration": {
+       "logUri": "s3://<s3 log bucket>"
+    }
+  }
+}' \
+--tags KeyName1=string \
+--job-driver '{
+    "sparkSubmitJobDriver": {
+        "entryPoint": "s3://<s3 bucket>/wordcount.py",
+        "entryPointArguments": [
+            "s3://<s3 bucket>/wordcount_output",
+            "'"$REGION"'"
+        ],
+        "sparkSubmitParameters": "--deploy-mode cluster --conf spark.executor.instances='"$EXEC_INST"' --conf spark.executor.memory='"$EXECMEM"' --conf spark.executor.cores=2 --conf spark.driver.cores=1"
+    }
+}'
+```
+>In bash shell, single quote won't expand variables. The tool can correctly handle the variables using double quote.
+
+##Wait for completion
+One difference between spark-submit and start-job-run is that spark-submit is waiting for the spark job to complete 
+but start-job-run is async. A wait_for_completion() bash shell function can be manually appended to the converted 
+command if needed.
+
+```
+function wait_for_completion() {
+    cat < /dev/stdin|jq -r '[.id, .virtualClusterId]|join(" ")'| { read id virtualClusterId; echo id=$id; echo virtualClusterId=$virtualClusterId;    while [ true ]
+	    do
+	       sleep 10
+	       state=$(aws emr-containers describe-job-run --id $id --virtual-cluster-id $virtualClusterId|jq -r '.jobRun.state')
+	       echo "$(date) job run state: $state"
+	       if [ "$state" = "COMPLETED" ]; then
+	            echo "job run id: $id completed"
+	            break
+	        elif [ "$state" = "FAILED" ]; then
+	            echo "job run id: $id failed. Exiting..."
+	            exit 1
+	        fi
+	    done; }
+}
+```
+>jq tool is required for json parsing.
+
+To use it, append wait_for_completion to the end of the command. 
+```
+# ----- Auto converted by startJobRunConverter.py -----
+aws emr-containers start-job-run \
+--name emreks-test-job \
+--virtual-cluster-id <virtual-cluster-id> \
+--execution-role-arn <execution-role-arn> \
+--release-label emr-6.4.0-latest \
+--configuration-overrides '{
+  "monitoringConfiguration": {
+    "cloudWatchMonitoringConfiguration": {
+      "logGroupName": "emrekstest",
+      "logStreamNamePrefix": "emreks_log_stream"
+    },
+    "s3MonitoringConfiguration": {
+       "logUri": "s3://<s3 log bucket>"
+    }
+  }
+}' \
+--tags KeyName1=string,k2=v2 \
+--job-driver '{
+    "sparkSubmitJobDriver": {
+        "entryPoint": "s3://<s3 bucket>/wordcount.py",
+        "entryPointArguments": [
+            "s3://<s3 bucket>/wordcount_output",
+            "'"$REGION"'"
+        ],
+        "sparkSubmitParameters": "--deploy-mode cluster --conf spark.executor.instances='"$EXEC_INST"' --conf spark.executor.memory='"$EXECMEM"' --conf spark.executor.cores=2 --conf spark.driver.cores=1"
+    }
+}'|wait_for_completion
+```

--- a/tools/start-job-run-converter/startJobRunConverter.py
+++ b/tools/start-job-run-converter/startJobRunConverter.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+
+OUTPUT_FILE_SUFFIX = "_converted"
+AUTO_CONVERT_MSG = "\n# ----- Auto converted by {} -----\n"
+
+SPARK_SUBMIT = "spark-submit"
+SPARK_UNARY_ARGUMENTS = {"-v", "--verbose"}
+CONVERTER_ARGUMENTS = {"file"}
+
+
+def add_quote(data, quote="\"", guard=" "):
+    if isinstance(data, list):
+        data = [quote + d + quote if guard in d and not d.startswith(quote) else d for d in data]
+    elif isinstance(data, str):
+        data = quote + data + quote if guard in data and not data.startswith(quote) else data
+    return data
+
+
+# In argparse, any internal - characters will be converted to _ characters to make sure the string
+# is a valid attribute name e.g. execution_role_arn.
+# This function change it back, e.g. execution-role-arn
+def normalize_arg_key(arg):
+    return arg.replace("_", "-")
+
+
+# In bash shell, single quote won't expand a variable. Need to close the single quotes,
+# insert variable, and then re-enter again.
+def convert_matched_var(match_obj):
+    if match_obj.group() is not None:
+        return "'\"" + match_obj.group() + "\"'"
+    return ""
+
+# This function assumes a valid spark-submit command, otherwise it throws exception
+def generate_start_job_cmd(spark_cmd_line, start_job_args):
+    start_job_cmd = "aws emr-containers start-job-run \\\n"
+    start_idx, curr_idx = 0, 0
+    while curr_idx < len(spark_cmd_line):
+        curr_arg = spark_cmd_line[curr_idx].strip()
+        if curr_arg:
+            if SPARK_SUBMIT in curr_arg:
+                start_idx = curr_idx + 1
+            elif curr_arg.startswith("-"):
+                if curr_arg not in SPARK_UNARY_ARGUMENTS:
+                    curr_idx += 1  # the argument is a pair e.g. --num-executors 50
+            else:
+                break
+        curr_idx += 1
+    spark_submit_parameters = add_quote(spark_cmd_line[start_idx: curr_idx])
+    entrypoint_location = spark_cmd_line[curr_idx]
+    entrypoint_arguments = add_quote(spark_cmd_line[curr_idx + 1:])
+    job_driver = {"sparkSubmitJobDriver": {
+        "entryPoint": entrypoint_location,
+        "entryPointArguments": entrypoint_arguments,
+        "sparkSubmitParameters": " ".join(spark_submit_parameters)
+    }}
+
+    res_str = add_quote(json.dumps(job_driver, indent=4), quote="'", guard="\n")
+    res_str = re.sub(r"\${?[0-9a-zA-Z_]+}?", convert_matched_var, res_str)
+    start_job_args["job_driver"] = res_str + "\n"
+
+    for k, v in start_job_args.items():
+        if k not in CONVERTER_ARGUMENTS and v:
+            start_job_cmd += "--" + normalize_arg_key(k) + " " + add_quote(v, quote="'", guard="\n") + " \\\n"
+    return start_job_cmd[:len(start_job_cmd) - 2] + "\n"
+
+
+def convert_file(input, output, extra_args, banner="\n"):
+    with open(input, "r") as input_fp:
+        with open(output, "w") as output_fp:
+            in_cmd = False
+            cmd_line = ""
+            for line in input_fp:
+                new_line = line.strip()
+                if new_line and ((new_line[0] != "#" and SPARK_SUBMIT in new_line) or in_cmd):
+                    output_fp.write("#" + line)  # Keep the original lines in comment
+                    in_cmd = True
+                    cmd_line += new_line
+                    if new_line[-1] != "\\":
+                        converted_cmd = generate_start_job_cmd(shlex.split(cmd_line), extra_args)
+                        output_fp.write(banner)
+                        output_fp.writelines(str(converted_cmd) + "\n")
+                        in_cmd = False
+                        cmd_line = ""
+                else:
+                    output_fp.write(line)
+
+
+if __name__ == '__main__':
+    # Create the parser
+    cmd_parser = argparse.ArgumentParser(description='A tool for converting spark-sumbit command line to EMR on EKS '
+                                                     'start-job-run.')
+
+    # Add the arguments
+    cmd_parser.add_argument('--file', help='the input spark-submit script file', required=True)
+    cmd_parser.add_argument('--name', help='The name of the job run')
+    cmd_parser.add_argument('--virtual-cluster-id', help='The virtual cluster ID for which the job run request is submitted', required=True)
+    cmd_parser.add_argument('--client-token', help='The client idempotency token of the job run request')
+    cmd_parser.add_argument('--execution-role-arn', help='The execution role ARN for the job run', required=True)
+    cmd_parser.add_argument('--release-label', help='The Amazon EMR release version to use for the job run', required=True)
+    cmd_parser.add_argument('--configuration-overrides', help='The configuration overrides for the job run')
+    cmd_parser.add_argument('--tags', help='The tags assigned to job runs')
+
+    args = cmd_parser.parse_args()
+
+    input_file = args.file
+    output_file = os.path.basename(input_file) + OUTPUT_FILE_SUFFIX
+
+    if os.path.exists(output_file):
+        print("Error: {} already exists.".format(output_file))
+        sys.exit(1)
+
+    convert_file(input_file, output_file, vars(args),
+                 AUTO_CONVERT_MSG.format(os.path.basename(sys.argv[0])))


### PR DESCRIPTION
This tool can be used to migrate spark-submit commands in a script to **aws emr-containers start-job-run**
and save the result to a new file with _converted suffix.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
