### PR TITLE
missing bracket in rbac patch script

### DIFF
--- a/tools/pvc-permission/rbac_patch.py
+++ b/tools/pvc-permission/rbac_patch.py
@@ -99,6 +99,7 @@ if __name__ == '__main__':
             "apiGroups": [""],
             "resources": ["persistentvolumeclaims"],
             "verbs": ["list", "create", "delete"]
+        }
         
     ]
 


### PR DESCRIPTION
rbac patch script had a missing bracket reported by an account team. The script was fully tested and worked fine after adding the bracket.
