### PR TITLE
add log4j2 to debug section

### DIFF
--- a/content/debugging/docs/change-log-level.md
+++ b/content/debugging/docs/change-log-level.md
@@ -8,8 +8,9 @@ To obtain more detail about their application or job submission, Spark applicati
 Log level of spark applications can be changed using the [EMR spark-log4j configuration classification.](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-configure.html)
 
 **Request**  
-pi.py used in the below request payload is from [spark examples](https://github.com/apache/spark/blob/master/examples/src/main/python/pi.py)  
-`spark-log4j` classification can be used to configure values in [log4j.properties](https://github.com/apache/spark/blob/master/conf/log4j.properties.template)
+The `pi.py` application script is from the [spark examples](https://github.com/apache/spark/blob/master/examples/src/main/python/pi.py). EMR on EKS has included the example located at`/usr/lib/spark/examples/src/main` for you to try.
+
+`spark-log4j` classification can be used to configure values in [log4j.properties](https://github.com/apache/spark/blob/branch-3.2/conf/log4j.properties.template) for EMR releases 6.7.0 or lower , and [log4j2.properties](https://github.com/apache/spark/blob/master/conf/log4j2.properties.template) for EMR releases 6.8.0+ .
 ```
 cat > Spark-Python-in-s3-debug-log.json << EOF
 {
@@ -19,8 +20,9 @@ cat > Spark-Python-in-s3-debug-log.json << EOF
   "releaseLabel": "emr-6.2.0-latest", 
   "jobDriver": {
     "sparkSubmitJobDriver": {
-      "entryPoint": "s3://<s3 prefix>/pi.py", 
-       "sparkSubmitParameters": "--conf spark.driver.cores=5 --conf spark.executor.memory=20G --conf spark.driver.memory=15G --conf spark.executor.cores=6"
+      "entryPoint": "local:///usr/lib/spark/examples/src/main/python/pi.py",
+      "entryPointArguments": [ "200" ],
+       "sparkSubmitParameters": "--conf spark.executor.memory=2G --conf spark.executor.cores=2 --conf spark.driver.memory=2G --conf spark.executor.instances=2"
     }
   }, 
   "configurationOverrides": {
@@ -57,6 +59,17 @@ aws emr-containers start-job-run --cli-input-json file:///Spark-Python-in-s3-deb
 ```
 
 The above request will print DEBUG logs in the spark driver and executor containers. The generated logs will be pushed to S3 and AWS Cloudwatch logs as configured in the request.
+
+Starting from the version 3.3.0, Spark has been [migrated from log4j1 to log4j2](https://issues.apache.org/jira/browse/SPARK-37814). EMR on EKS allows you still write the log4j properties to the same `"classification": "spark-log4j"`, however it now needed to be log4j2.properties, such as 
+```
+      {
+        "classification": "spark-log4j",
+        "properties": {
+          "rootLogger.level" : "DEBUG"
+          }
+      }
+
+```
 
 ####**Custom log4j properties**  
 Download log4j properties from [here](https://github.com/apache/spark/blob/master/conf/log4j.properties.template). Edit log4j.properties with log level as required. Save the edited log4j.properties in a mounted volume. In this example log4j.properties is placed in a s3 bucket that is mapped to a [FSx for Lustre filesystem](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html). 

--- a/content/debugging/docs/change-log-level.md
+++ b/content/debugging/docs/change-log-level.md
@@ -60,7 +60,7 @@ aws emr-containers start-job-run --cli-input-json file:///Spark-Python-in-s3-deb
 
 The above request will print DEBUG logs in the spark driver and executor containers. The generated logs will be pushed to S3 and AWS Cloudwatch logs as configured in the request.
 
-Starting from the version 3.3.0, Spark has been [migrated from log4j1 to log4j2](https://issues.apache.org/jira/browse/SPARK-37814). EMR on EKS allows you still write the log4j properties to the same `"classification": "spark-log4j"`, however it now needed to be log4j2.properties, such as 
+Starting from the version 3.3.0, Spark has been [migrated from log4j1 to log4j2](https://issues.apache.org/jira/browse/SPARK-37814). EMR on EKS allows you still write the log4j properties to the same `"classification": "spark-log4j"`, however it now needs to be log4j2.properties, such as 
 ```
       {
         "classification": "spark-log4j",


### PR DESCRIPTION
Starting from the version 3.3.0 (EMR6.8+) , Spark has been migrated from log4j1 to log4j2. Our debug section needs additional guide.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
