### PR TITLE
Update prometheus-helm-values.yaml

### DIFF
--- a/tools/emr-vertical-autoscaling/prometheus-helm-values.yaml
+++ b/tools/emr-vertical-autoscaling/prometheus-helm-values.yaml
@@ -47,5 +47,8 @@ kube-state-metrics:
     - apiGroups: ["autoscaling.k8s.io"]
       resources: ["verticalpodautoscalers"]
       verbs: ["list", "watch"]
+    - apiGroups: ["apiextensions.k8s.io"]
+      resources: ["customresourcedefinitions"]
+      verbs: ["list", "watch"]
   metricLabelsAllowlist:
     - "pods=[emr-containers.amazonaws.com/dynamic.sizing.signature]"


### PR DESCRIPTION
Fixes RBAC error. Logs are as follows:
```
failed to list apiextensions.k8s.io/v1, Resource=customresourcedefinitions: customresourcedefinitions.apiextensions.k8s.io is forbidden: User "system:serviceaccount:prometheus:prometheus-kube-state-metrics" ca │
│ .go:231: Failed to watch apiextensions.k8s.io/v1, Resource=customresourcedefinitions: failed to list apiextensions.k8s.io/v1, Resource=customresourcedefinitions: customresourcedefinitions.apiextensions.k8s.io is forbid │
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
