### PR TITLE
Automatically create kubernetes service object to connect to Spark UI via Reverse Proxy 

### DIFF
--- a/content/troubleshooting/docs/reverse-proxy-sparkui.md
+++ b/content/troubleshooting/docs/reverse-proxy-sparkui.md
@@ -96,7 +96,7 @@ kubectl auth can-i patch  service -n $EMR_CONTAINERS_NAMESPACE --as=system:servi
 
 ## Launch EMR on EKS jobs via Spark Operator
 
-1.Submit two test jobs using EMR on EKS's Spark Operator. The sample job scripts [emr-eks-spark-example-01.yaml](#emr-eks-spark-example-01yaml) and [emr-eks-spark-example-02.yaml](#emr-eks-spark-example-02yaml) can be found in the Appendix section. 
+1.Submit two test jobs using EMR on EKS's Spark Operator. The sample job scripts [spark-operator-example-01.yaml](#spark-operator-example-01yaml) and [spark-operator-example-02.yaml](#spark-operator-example-02yaml) can be found in the Appendix section. 
 
 * The `spec.driver.Serviceaccount` attribute should be updated based on your own [IAM Role for Service Account (IRSA)](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) setup in EMR on EKS.
 * The `namespace` attribute should be updated to namespace where EMR on EKS is running

--- a/content/troubleshooting/docs/reverse-proxy-sparkui.md
+++ b/content/troubleshooting/docs/reverse-proxy-sparkui.md
@@ -1,20 +1,28 @@
 # **Connect to SparkUI without Port Fowarding**
 
-This is an example of connecting to SparkUI running on Spark's driver pod via a reserve proxy solution, without an access to the kubectl tool or AWS console. The flow of Spark UI access is as follows,
-User's Browser -> Kubernetes Ingress (ALB - Application Load Balancer) -> Spark UI Reverse Proxy -> Kubernetes Service -> Spark Driver Pod
+This is an example of connecting to SparkUI running on Spark's driver pod via a reserve proxy solution, without an access to the kubectl tool or AWS console. The flow of Spark UI access is as follows,  
+User's Browser --> Kubernetes Ingress (ALB - Application Load Balancer) --> Spark UI Reverse Proxy --> Kubernetes Service --> Spark Driver Pod
+
+The reverse proxy uses URI path to redirects the traffic to corresponding driver pod via Kubernetes service object. The name of the service should be `<last-segment-of-URI-path>-ui-svc` and following properties needs to be set in the spark configuration.
+
+|Configuratin|Example|Description|
+|---|---|---|
+|spark.ui.proxyBase|/sparkui/my-spark-app|The URI path on which to access the particular job's spark UI. This is divided into two parts, first is base URI (i.e. /sparkui) and second is the name used to redirect the traffic to corresponding service. e.g. if URI path is "/sparkui/my-spark-app" then reverse proxy redirects the traffic to service named "my-spark-app-ui-svc".  Note: Don't change the /sparkui/ base URI as its a default base URI used by Spark revserve proxy|
+|spark.ui.proxyRedirectUri|/|Redirect URI. Keep it "/".
 
 The URL to access Spark UI is,  
-http://YOUR_INGRESS_ADDRESS:PORT/sparkui/YOUR_SPARK_APP_NAME
+`http://YOUR_INGRESS_ADDRESS:PORT/<spark.ui.proxyBase>`  
+e.g. http://k8s-default-sparkui-2d325c0434-124141735.us-west-2.elb.amazonaws.com:80/sparkui/my-spark-app
 
 Where,  
-* YOUR_INGRESS_ADDRESS:PORT = Ingress ALB's DNS name and port. e.g. http://k8s-default-sparkui-2d325c0434-124141735.us-west-2.elb.amazonaws.com:80  
-* /sparkui/YOUR_SPARK_APP_NAME: Property set in "spark.ui.proxyBase". e.g. `spark.ui.proxyBase: /sparkui/my-spark-app`. (Note: Don't change the /sparkui/ prefix as its default prefix used by Spark revserve proxy) 
+* YOUR_INGRESS_ADDRESS:PORT* :- Ingress ALB's DNS name and port. 
 
 We demostrate how to set up Ingress and Reverse Proxy. Then launch the jobs via three EMR on EKS deployment methods: Spark Operator, JobRun API, and spark-submit. The spark operator creates the Kubernetes service object with target as driver pod for each job. However, JobRun API and spark-submit do not create Kubernetes service object so we use driver pod's "postStart" lifecycle hook to create the service object in driver pod's template.
 
+
 ## Deploy SparkUI reserve proxy and an Ingress in a default namespace
 
-1.Create a SparkUI reverse proxy and an Ingress (ALB) in a default namespace, which is a different namespace from your EMR on EKS virtual cluster environment. It can be configured to the EMR's namespace if neccessary.
+Create a SparkUI reverse proxy and an Ingress (ALB) in a default namespace, which is a different namespace from your EMR on EKS virtual cluster environment. It can be configured to the EMR's namespace if neccessary.
 
 The [sample yaml file](#deploymentyaml) is in the Appendix section. Make sure the EMR on EKS's namespace at the line #25 in `deployment.yaml` is updated if needed:
 ```bash
@@ -28,38 +36,74 @@ kubectl apply -f deployment.yaml
 EKS Admin can provide the ALB endpoint address to users via the command: 
 ```bash
 kubectl get ingress
-```
-2. If you are going to use JobRun API or spark-submit to launch the jobs then grant permissions to Driver pod's Service Account to be able to manage Kubernetes Service Object
 
-EKS Admin can grant the list, create, update & delete for Kubernetes Service Object to spark driver role via the command: 
+NAME       CLASS               HOSTS   ADDRESS                                                                PORTS   AGE
+spark-ui   alb-ingress-class   *       k8s-default-sparkui-627e515973-123456789.us-west-2.elb.amazonaws.com   80      14d
+```
+
+## Grant permissions to Driver pod's Service Account
+<div style="border: 1px solid red; padding: 10px; background-color: #f8d7da;">
+  <strong>NOTE:</strong> This step is required for JobRun API or spark-submit. It is NOT required for spark operator.
+</div>  
+If you are going to use JobRun API or spark-submit to launch the jobs then grant permissions to Kubernetes role bound to Driver pod's Service Account to be able to manage Kubernetes Service Object.
+
+The client & driver roles and corresponding service accounts are can be queried via command:
+```
+export EMR_CONTAINERS_NAMESPACE=emr-on-eks
+
+kubectl get role -n $EMR_CONTAINERS_NAMESPACE                                                                                                                     
+NAME                               CREATED AT
+emr-containers                     2024-10-19T08:56:15Z
+emr-containers-role-spark-client   2024-10-19T09:57:37Z
+emr-containers-role-spark-driver   2024-10-19T09:57:37Z
+
+kubectl get serviceaccount -n $EMR_CONTAINERS_NAMESPACE 
+NAME                                                                           SECRETS   AGE
+default                                                                        0         62m
+emr-containers-sa-spark-client-1234567890-abcdefgh123456ijklmno7890prrst       0         28s
+emr-containers-sa-spark-driver-1234567890-abcdefgh123456ijklmno7890prrst       0         28s
+emr-containers-sa-spark-executor-1234567890-abcdefgh123456ijklmno7890prrst     0         28s
+
+kubectl get rolebindings.rbac.authorization.k8s.io -n $EMR_CONTAINERS_NAMESPACE 
+NAME                                                                       ROLE                                    AGE
+emr-containers                                                             Role/emr-containers                     62m
+emr-containers-rb-spark-client-1234567890-abcdefgh123456ijklmno7890prrst   Role/emr-containers-role-spark-client   46s
+emr-containers-rb-spark-driver-1234567890-abcdefgh123456ijklmno7890prrst   Role/emr-containers-role-spark-driver   46s
+```
+
+EKS Admin can grant the list, create, update & delete for Kubernetes Service Object to spark driver role via the command:  
+
+Ensure to set `EMR_CONTAINERS_ROLE_SPARK_DRIVER` to Kubernetes role binded to driver pod's service account and `EMR_CONTAINERS_NAMESPACE` to Kubernetes namespace in which EMR on EKS is running.
 
 ```bash
 export EMR_CONTAINERS_ROLE_SPARK_DRIVER=emr-containers-role-spark-driver
-export EMR_CONTAINERS_NAMESPACE=emr
-kubectl patch role $EMR_CONTAINERS_ROLE_SPARK_DRIVER -namespace $EMR_CONTAINERS_NAMESPACE --type='json' -p='[{"op": "add", "path": "/rules/-", "value": {"apiGroups": [""], "resources": ["services"], "verbs": ["list", "create", "update", "delete"]}}]'
+export EMR_CONTAINERS_NAMESPACE=emr-on-eks
+kubectl patch role $EMR_CONTAINERS_ROLE_SPARK_DRIVER -n $EMR_CONTAINERS_NAMESPACE --type='json' -p='[{"op": "add", "path": "/rules/-", "value": {"apiGroups": [""], "resources": ["services"], "verbs": ["list", "create", "update", "delete", "patch"]}}]'
 ```
 
-Set EMR_CONTAINERS_ROLE_SPARK_DRIVER to role used by driver pod and EMR_CONTAINERS_NAMESPACE to namespace in which EMR on EKS is running.
+EKS Admin can varify the access to Driver Pod's Service Account via the command:  
 
-EKS Admin can varify the access to Driver Pod's Service Account via the command: 
+Ensure to set `EMR_CONTAINERS_SA_SPARK_DRIVER` to service account binded to above role. The output of each command should be "yes"
+
 ```bash
-export EMR_CONTAINERS_SA_SPARK_DRIVER=emr-containers-sa-spark
-kubectl auth can-i list   service -n default --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
-kubectl auth can-i create service -n default --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
-kubectl auth can-i update service -n default --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
-kubectl auth can-i delete service -n default --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
+export EMR_CONTAINERS_SA_SPARK_DRIVER=emr-containers-sa-spark-driver-1234567890-abcdefgh123456ijklmno7890prrst
+kubectl auth can-i list   service -n $EMR_CONTAINERS_NAMESPACE --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
+kubectl auth can-i create service -n $EMR_CONTAINERS_NAMESPACE --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
+kubectl auth can-i update service -n $EMR_CONTAINERS_NAMESPACE --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
+kubectl auth can-i delete service -n $EMR_CONTAINERS_NAMESPACE --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
+kubectl auth can-i patch  service -n $EMR_CONTAINERS_NAMESPACE --as=system:serviceaccount:$EMR_CONTAINERS_NAMESPACE:$EMR_CONTAINERS_SA_SPARK_DRIVER
 ```
-Set EMR_CONTAINERS_SA_SPARK_DRIVER to service account used by driver pod
-
 
 ## Launch EMR on EKS jobs via Spark Operator
 
-1. Submit two test jobs using EMR on EKS's Spark Operator. The sample job scripts [emr-eks-spark-example-01.yaml](#emr-eks-spark-example-01yaml) and [emr-eks-spark-example-02.yaml](#emr-eks-spark-example-02yaml) can be found in the Appendix section. The "spec.driver.Serviceaccount" attribute should be updated based on your own [IAM Role for Service Account (IRSA)](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) setup in EMR on EKS.
+1.Submit two test jobs using EMR on EKS's Spark Operator. The sample job scripts [emr-eks-spark-example-01.yaml](#emr-eks-spark-example-01yaml) and [emr-eks-spark-example-02.yaml](#emr-eks-spark-example-02yaml) can be found in the Appendix section. 
 
-Remember to specify the Spark configuration at line #16 `spark.ui.proxyBase: /sparkui/YOUR_SPARK_APP_NAME`, eg. `spark.ui.proxyBase: /sparkui/test-02`.
+* The `spec.driver.Serviceaccount` attribute should be updated based on your own [IAM Role for Service Account (IRSA)](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) setup in EMR on EKS.
+* The `namespace` attribute should be updated to namespace where EMR on EKS is running
+* Remember to specify the Spark configuration at line #16 `spark.ui.proxyBase: /sparkui/YOUR_SPARK_APP_NAME`, eg. `spark.ui.proxyBase: /sparkui/spark-example-01`.
 ```bash
-kubectl apply -f emr-eks-spark-example-01.yaml
-kubectl apply -f emr-eks-spark-example-02.yaml
+kubectl apply -f spark-operator-example-01.yaml
+kubectl apply -f spark-operator-example-02.yaml
 ```
 
 2.Go to a web browser, then access their Spark Web UI while jobs are still running.
@@ -68,50 +112,49 @@ The Web UI address is in the format of `http://YOUR_INGRESS_ADDRESS:PORT/sparkui
 
 ```
 http://k8s-default-sparkui-2d325c0434-124141735.us-west-2.elb.amazonaws.com:80/sparkui/spark-example-01
-http://k8s-default-sparkui-2d325c0434-124141735.us-west-2.elb.amazonaws.com:80/sparkui/test-02
+http://k8s-default-sparkui-2d325c0434-124141735.us-west-2.elb.amazonaws.com:80/sparkui/spark-example-02
 ```
 
-
- 
 ## Launch EMR on EKS jobs via Job Run API
 
-1.Upload the driver pod template to S3 bucket. It assumes that template is copied under "templates" prefix (folder.)
+1.Upload the driver pod template to S3 bucket. It is assumed that template is copied under prefix (folder) `/templates` inside bucket.
 
 ```bash
-export S3BUCKET=YOUR_S3_BUCKET
-aws s3 cp driver-pod-template.yaml $S3BUCKET/templates
+aws s3 cp driver-pod-template.yaml YOUR_S3_BUCKET/templates
 ```
 
-2.Ensure that Job execution role has access to S3 bucket
+2.Ensure that Job execution role has access to above S3 bucket.
 
 
-2.Update the the environment variables in the sample job submission script:
+3.Set the values for `YOUR_APP_NAME`, `YOUR_S3_BUCKET`, `YOUR_EMR_VIRTUAL_CLUSTER_NAME`, `YOUR_EMR_JOB_EXECUTION_ROLE` and run the sample job submission script below:
+
 
 ```bash
+export YOUR_APP_NAME=start-job-run-pi
+export S3BUCKET=YOUR_S3_BUCKET
+
 export EMR_VIRTUAL_CLUSTER_NAME=YOUR_EMR_VIRTUAL_CLUSTER_NAME
-export AWS_REGION=YOUR_AWS_REGION
-export APP_NAME=job-run-api
+export VIRTUAL_CLUSTER_ID=$(aws emr-containers list-virtual-clusters --query "virtualClusters[?name == '$EMR_VIRTUAL_CLUSTER_NAME' && state == 'RUNNING'].id" --output text)
 
 export ACCOUNTID=$(aws sts get-caller-identity --query Account --output text)
-export VIRTUAL_CLUSTER_ID=$(aws emr-containers list-virtual-clusters --query "virtualClusters[?name == '$EMR_VIRTUAL_CLUSTER_NAME' && state == 'RUNNING'].id" --output text)
-export EMR_ROLE_ARN=arn:aws:iam::$ACCOUNTID:role/$EMR_VIRTUAL_CLUSTER_NAME-execution-role
+export EMR_ROLE_ARN=arn:aws:iam::$ACCOUNTID:role/YOUR_EMR_JOB_EXECUTION_ROLE
 
 aws emr-containers start-job-run \
 --virtual-cluster-id $VIRTUAL_CLUSTER_ID \
---name $APP_NAME \
+--name $YOUR_APP_NAME \
 --execution-role-arn $EMR_ROLE_ARN \
 --release-label emr-7.1.0-latest \
 --job-driver '{
 "sparkSubmitJobDriver": {
     "entryPoint": "local:///usr/lib/spark/examples/jars/spark-examples.jar", 
     "entryPointArguments": ["100000"],
-    "sparkSubmitParameters": "--class org.apache.spark.examples.SparkPi --conf spark.executor.instances=1 --conf spark.kubernetes.driver.podTemplateFile=s3://$S3BUCKET/templates/driver-pod-template.yaml" }}' \
+    "sparkSubmitParameters": "--class org.apache.spark.examples.SparkPi --conf spark.executor.instances=1 --conf spark.kubernetes.driver.podTemplateFile=s3://'${S3BUCKET}'/templates/driver-pod-template.yaml" }}' \
 --configuration-overrides '{
 "applicationConfiguration": [
     {
     "classification": "spark-defaults", 
     "properties": {
-        "spark.ui.proxyBase": "/sparkui/`$APP_NAME`",
+        "spark.ui.proxyBase": "/sparkui/'${YOUR_APP_NAME}'",
         "spark.ui.proxyRedirectUri": "/"
     }}]}'
 ```
@@ -119,51 +162,57 @@ aws emr-containers start-job-run \
 
 2.Go to a web browser, then access their Spark Web UI while jobs are still running.
 ```
-http://<YOUR_INGRESS_ADDRESS>/sparkui/<APP_NAME>
+http://<YOUR_INGRESS_ADDRESS>/sparkui/<YOUR_APP_NAME>
 ```
 Admin can get the ingress address by the CLI:
 ```bash
 kubectl get ingress
 ```
-The SparkUI service looks like this:
+The SparkUI service is created on postStart event of driver container and looks like this:
 ```bash
-kubectl get svc -n emr
+kubectl get service -n $EMR_CONTAINERS_NAMESPACE
 
 NAME                  TYPE      CLUSTER-IP  EXTERNAL-IP   PORT(S)  AGE
-job-run-api-ui-svc ClusterIP 10.100.233.186  <none>      4040/TCP   9s
+YOUR_APP_NAME-ui-svc ClusterIP 10.100.233.186  <none>      4040/TCP   9s
 ```
 
 ## Launch EMR on EKS jobs by Spark Submit:
 
-1.Create an EMR on EKS pod with a service account that has the [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) associated
+1.Create an EMR on EKS pod with a service account that has the [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) associated and have permission to access the S3 bucket which has pod template.
 ```bash
+export EMR_CONTAINERS_NAMESPACE=emr-on-eks
+export EMR_CONTAINERS_SA_SPARK_CLIENT=emr-containers-sa-spark-client-1234567890-abcdefgh123456ijklmno7890prrst
+
 kubectl run -it emrekspod \
 --image=public.ecr.aws/emr-on-eks/spark/emr-7.1.0:latest \
---overrides='{ "spec": {"serviceAccount": "emr-containers-sa-spark"}}' \
---command -n spark-operator /bin/bash
+--overrides='{ "spec": {"serviceAccount": "'${EMR_CONTAINERS_SA_SPARK_CLIENT}'"}}' \
+--command -n $EMR_CONTAINERS_NAMESPACE /bin/bash
 ```
 2.After login into the "emrekspod" pod, submit the job:
 ```bash
-export APP_NAME=sparksubmittest
+export YOUR_APP_NAME=spark-submit-pi
 export S3BUCKET=YOUR_S3_BUCKET
+export EMR_CONTAINERS_NAMESPACE=emr-on-eks
+export EMR_CONTAINERS_SA_SPARK_DRIVER=emr-containers-sa-spark-driver-1234567890-abcdefgh123456ijklmno7890prrst
 
 spark-submit \
 --master k8s://$KUBERNETES_SERVICE_HOST:443 \
 --deploy-mode cluster \
---name $APP_NAME \
+--name $YOUR_APP_NAME \
 --class org.apache.spark.examples.SparkPi \
 --conf spark.kubernetes.driver.podTemplateFile=s3://$S3BUCKET/templates/driver-pod-template.yaml \
---conf spark.ui.proxyBase=/sparkui/$APP_NAME \
+--conf spark.kubernetes.driver.podTemplateContainerName=spark-kubernetes-driver \
+--conf spark.ui.proxyBase=/sparkui/$YOUR_APP_NAME \
 --conf spark.ui.proxyRedirectUri="/" \
 --conf spark.kubernetes.container.image=public.ecr.aws/emr-on-eks/spark/emr-7.1.0:latest \
---conf spark.kubernetes.authenticate.driver.serviceAccountName=emr-containers-sa-spark \
---conf spark.kubernetes.namespace=spark-operator \
+--conf spark.kubernetes.authenticate.driver.serviceAccountName=$EMR_CONTAINERS_SA_SPARK_DRIVER \
+--conf spark.kubernetes.namespace=$EMR_CONTAINERS_NAMESPACE \
 local:///usr/lib/spark/examples/jars/spark-examples.jar 100000
 ```
 
 3.Go to a web browser, then access their Spark Web UI while jobs are still running.
 ```
-http://<YOUR_INGRESS_ADDRESS>/sparkui/<APP_NAME>
+http://<YOUR_INGRESS_ADDRESS>/sparkui/<YOUR_APP_NAME>
 ```
 Admin can get the ingress address by the CLI:
 ```bash
@@ -205,7 +254,7 @@ spec:
           - '/usr/bin/spark-ui-reverse-proxy'
         args:
           # EMR on EKS's namespace
-          - -namespace=spark-operator
+          - -namespace=emr-on-eks
         resources:
           requests:
             cpu: 500m
@@ -266,13 +315,13 @@ spec:
 ```
 
 
-### emr-eks-spark-example-01.yaml
+### spark-operator-example-01.yaml
 ```yaml
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
 metadata:
   name: spark-example-01
-  namespace: spark-operator
+  namespace: emr-on-eks
 spec:
   type: Scala
   image: public.ecr.aws/emr-on-eks/spark/emr-7.1.0:latest
@@ -291,18 +340,18 @@ spec:
     memory: "1g"
     serviceAccount: emr-containers-sa-spark
   executor:
-    cores: 2
+    cores: 1
     instances: 2
-    memory: "5120m"
+    memory: "2g"
 ```
 
-### emr-eks-spark-example-02.yaml
+### spark-operator-example-02.yaml
 ```yaml
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
 metadata:
   name: spark-example-02
-  namespace: spark-operator
+  namespace: emr-on-eks
 spec:
   type: Scala
   image: public.ecr.aws/emr-on-eks/spark/emr-7.1.0:latest
@@ -313,7 +362,7 @@ spec:
   restartPolicy:
     type: Never
   sparkConf:
-    spark.ui.proxyBase: /sparkui/test-02
+    spark.ui.proxyBase: /sparkui/spark-example-02
     spark.ui.proxyRedirectUri: /
   driver:
     cores: 1

--- a/content/troubleshooting/docs/reverse-proxy-sparkui.md
+++ b/content/troubleshooting/docs/reverse-proxy-sparkui.md
@@ -1,12 +1,19 @@
 # **Connect to SparkUI without Port Fowarding**
 
-This is an example of connecting to SparkUI running on Spark's driver pod via a reserve proxy solution, without an access to the kubectl tool or AWS console. We demostrate how to set it up via three EMR on EKS deployment methods: Spark Operator, JobRun API, and spark-submit.
+This is an example of connecting to SparkUI running on Spark's driver pod via a reserve proxy solution, without an access to the kubectl tool or AWS console. The flow of Spark UI access is as follows,
+User's Browser -> Kubernetes Ingress (ALB - Application Load Balancer) -> Spark UI Reverse Proxy -> Kubernetes Service -> Spark Driver Pod
 
-## Launch EMR on EKS jobs via Spark Operator
+The URL to access Spark UI is,
+http://<YOUR_INGRESS_ADDRESS>/sparkui/YOUR_SPARK_APP_NAME
+Where,
+YOUR_INGRESS_ADDRESS: ALB's DNS name and port. e.g. http://k8s-default-sparkui-2d325c0434-124141735.us-west-2.elb.amazonaws.com:80
+/sparkui/YOUR_SPARK_APP_NAME: Property set in "spark.ui.proxyBase". eg. `spark.ui.proxyBase: /sparkui/my-spark-app`.
 
-There are 3 Steps to set up in EKS:
+We demostrate how to set up Ingress and Reverse Proxy. Then launch the jobs via three EMR on EKS deployment methods: Spark Operator, JobRun API, and spark-submit. The spark operator creates the Kubernetes service object poiniting to driver pod for each job. However, JobRun API and spark-submit do not create Kubernetes service object so we use driver pod's "postStart" lifecycle hook in driver pod's template to create the service object. 
 
-1.Create a SparkUI reverse proxy and an ALB in a default namespace, which is a different namespace from your EMR on EKS virtual cluster environment. It can be configured to the EMR's namespace if neccessary.
+## Deploy SparkUI reserve proxy and an Ingress in a default namespace
+
+1.Create a SparkUI reverse proxy and an Ingress (ALB) in a default namespace, which is a different namespace from your EMR on EKS virtual cluster environment. It can be configured to the EMR's namespace if neccessary.
 
 The [sample yaml file](#deploymentyaml) is in the Appendix section. Make sure the EMR on EKS's namespace at the line #25 in `deployment.yaml` is updated if needed:
 ```bash
@@ -14,9 +21,17 @@ kubectl apply -f deployment.yaml
 ```
 <div style="border: 1px solid red; padding: 10px; background-color: #f8d7da;">
   <strong>NOTE:</strong> The example file is not production ready. The listen port 80 is not recommended. Make sure to stronger your Application Load Balance's security posture before deploy it to your production environment.
-</div>
+</div>  
 
-2.Submit two test jobs using EMR on EKS's Spark Operator. The sample job scripts [emr-eks-spark-example-01.yaml](#emr-eks-spark-example-01yaml) and [emr-eks-spark-example-02.yaml](#emr-eks-spark-example-02yaml) can be found in the Appendix section. The "spec.driver.Serviceaccount" attribute should be updated based on your own [IAM Role for Service Account (IRSA)](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) setup in EMR on EKS.
+  
+EKS Admin can provide the ALB endpoint address to users via the command: 
+```bash
+kubectl get ingress
+```
+
+## Launch EMR on EKS jobs via Spark Operator
+
+1. Submit two test jobs using EMR on EKS's Spark Operator. The sample job scripts [emr-eks-spark-example-01.yaml](#emr-eks-spark-example-01yaml) and [emr-eks-spark-example-02.yaml](#emr-eks-spark-example-02yaml) can be found in the Appendix section. The "spec.driver.Serviceaccount" attribute should be updated based on your own [IAM Role for Service Account (IRSA)](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) setup in EMR on EKS.
 
 Remember to specify the Spark configuration at line #16 `spark.ui.proxyBase: /sparkui/YOUR_SPARK_APP_NAME`, eg. `spark.ui.proxyBase: /sparkui/test-02`.
 ```bash
@@ -24,7 +39,7 @@ kubectl apply -f emr-eks-spark-example-01.yaml
 kubectl apply -f emr-eks-spark-example-02.yaml
 ```
 
-3.Go to a web browser, then access their Spark Web UI while jobs are still running.
+2.Go to a web browser, then access their Spark Web UI while jobs are still running.
 
 The Web UI address is in the format of `http://ALB_ENDPOINT_ADDRESS:PORT/sparkui/YOUR_SPARK_APP_NAME`. For example:
 
@@ -33,10 +48,7 @@ http://k8s-default-sparkui-2d325c0434-124141735.us-west-2.elb.amazonaws.com:80/s
 http://k8s-default-sparkui-2d325c0434-124141735.us-west-2.elb.amazonaws.com:80/sparkui/test-02
 ```
 
-EKS Admin can provide the ALB endpoint address to users via the command: 
-```bash
-kubectl get ingress
-```
+
  
 ## Launch EMR on EKS jobs via Job Run API
 
@@ -54,7 +66,7 @@ export S3BUCKET=$EMR_VIRTUAL_CLUSTER_NAME-$ACCOUNTID-$AWS_REGION
 
 aws emr-containers start-job-run \
 --virtual-cluster-id $VIRTUAL_CLUSTER_ID \
---name $app_name \
+--name $APP_NAME \
 --execution-role-arn $EMR_ROLE_ARN \
 --release-label emr-7.1.0-latest \
 --job-driver '{
@@ -67,22 +79,19 @@ aws emr-containers start-job-run \
     {
     "classification": "spark-defaults", 
     "properties": {
-        "spark.ui.proxyBase": "/sparkui/`$app_name`",
+        "spark.ui.proxyBase": "/sparkui/`$APP_NAME`",
         "spark.ui.proxyRedirectUri": "/"
     }}]}'
 ```
 
-2.Once the job's driver pod is running, create a kubernetes service based on the driver pod name. Ensure its name contains the suffix **ui-svc**:
+
+2.Go to a web browser, then access their Spark Web UI while jobs are still running.
+```
+http://<YOUR_INGRESS_ADDRESS>/sparkui/<app_name>
+```
+Admin can get the ingress address by the CLI:
 ```bash
-# query the driver pod name
-job_id=$(aws emr-containers list-job-runs --virtual-cluster-id $VIRTUAL_CLUSTER_ID --query "jobRuns[?name=='$app_name' && state=='RUNNING'].id" --output text)
-driver_pod_name=$(kubectl get po -n emr | grep $job_id-driver | awk '{print $1}')
-# create a k8s service
-kubectl expose po -n emr \
---port=4040 \
---target-port 4040 \
---name=$app_name-ui-svc \
-$driver_pod_name
+kubectl get ingress
 ```
 The SparkUI service looks like this:
 ```bash
@@ -92,14 +101,6 @@ NAME                  TYPE      CLUSTER-IP  EXTERNAL-IP   PORT(S)  AGE
 job-run-api-ui-svc ClusterIP 10.100.233.186  <none>      4040/TCP   9s
 ```
 
-3.Finally, access the SparkUI in this format:
-```
-http://<YOUR_INGRESS_ADDRESS>/sparkui/<app_name>
-```
-Admin can get the ingress address by the CLI:
-```bash
-kubectl get ingress
-```
 ## Launch EMR on EKS jobs by Spark Submit:
 
 1.Create an EMR on EKS pod with a service account that has the [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) associated
@@ -125,21 +126,21 @@ spark-submit \
 --conf spark.kubernetes.namespace=spark-operator \
 local:///usr/lib/spark/examples/jars/spark-examples.jar 100000
 ```
-3.As soon as the driver pod is running, create a kubernetes service for Spark UI and ensure its name has the suffix of **ui-svc**:
+
+3.Go to a web browser, then access their Spark Web UI while jobs are still running.
+```
+http://<YOUR_INGRESS_ADDRESS>/sparkui/<app_name>
+```
+Admin can get the ingress address by the CLI:
 ```bash
-export app_name=sparksubmittest
-# get the running driver pod name
-driver_pod_name=$(kubectl get po -n spark-operator | grep -E 'sparksubmittest-.*-driver' | grep 'Running' | awk '{print $1}')
+kubectl get ingress
+```
+The SparkUI service looks like this:
+```bash
+kubectl get svc -n emr
 
-# OPTIONAL - remove existing service if needed
-kubectl delete svc $app_name-ui-svc -n spark-operator
-
-# create k8s service
-kubectl expose po -n spark-operator \
---port=4040 \
---target-port 4040 \
---name=$app_name-ui-svc \
-$driver_pod_name
+NAME                  TYPE      CLUSTER-IP  EXTERNAL-IP   PORT(S)  AGE
+job-run-api-ui-svc ClusterIP 10.100.233.186  <none>      4040/TCP   9s
 ```
 
 ## Appendix
@@ -289,4 +290,51 @@ spec:
     cores: 1
     instances: 1
     memory: "2120m"
+```
+
+### driver-pod-template.yaml
+```yaml
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+- name: spark-kubernetes-driver # This will be interpreted as driver Spark main container
+    lifecycle:
+      postStart:
+        exec:
+          command: 
+            - /bin/bash
+            - -c
+            - |
+              # Set Variables
+              export K8S_NAMESPACE=`cat  /run/secrets/kubernetes.io/serviceaccount/namespace`
+              export SPARK_UI_PROXYBASE=`grep spark.ui.proxyBase ${SPARK_CONF_DIR}/spark.properties | rev |  cut -d/ -f1 | rev`
+              export SPARK_UI_SERVICE_NAME=${SPARK_UI_PROXYBASE}-ui-svc
+              
+              cat > /tmp/service.yaml << EOF
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: ${SPARK_UI_SERVICE_NAME}
+                namespace: $K8S_NAMESPACE
+                labels:
+                  spark-app-selector: ${SPARK_APPLICATION_ID}
+                  spark-role: driver
+              spec:
+                ports:
+                - port: 4040
+                  targetPort: 4040
+                  protocol: TCP
+                selector:
+                  spark-app-selector: ${SPARK_APPLICATION_ID}
+                  spark-role: driver
+                type: ClusterIP
+              EOF
+
+              if [ -n "${SPARK_UI_PROXYBASE:-}" ]; then
+                # Create or replace the service 
+                curl -X PUT https://${KUBERNETES_SERVICE_HOST}/api/v1/namespaces/${K8S_NAMESPACE}/services/${SPARK_UI_SERVICE_NAME} -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type: application/yaml" --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --data-binary @/tmp/service.yaml > /tmp/service.out
+              else
+                echo spark.ui.proxyBase is NOT set in ${SPARK_CONF_DIR}/spark.properties > /tmp/service.out
+              fi
 ```


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
The reverse proxy solution uses URI path to redirects the traffic to corresponding driver pod via Kubernetes service object.  There are three EMR on EKS deployment methods: Spark Operator, JobRun API, and spark-submit. The spark operator creates the Kubernetes service object with target as driver pod for each job. However, JobRun API and spark-submit do not create Kubernetes service object. So, we use driver pod's "postStart" lifecycle hook to create the service object when driver pod is created. "postStart" lifecycle hook is defined in driver pod template and used while launching the job via JobRun API or spark-submit to automatically create the Kubernetes service object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
