### PR TITLE
Add QPS and Burst Settings to binpacking scheduler

### DIFF
--- a/content/performance/docs/binpack.md
+++ b/content/performance/docs/binpack.md
@@ -48,7 +48,17 @@ We do not recommend build the kube-scheduler by yourself, you can leverage the e
 - **Amazon EKS 1.28 image:** public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.28.11-eks-1-28-latest
 - **Amazon EKS 1.29 image:** public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.29.6-eks-1-29-18
 
-
+NOTE: If your binpacking pod throttles for a large scale workload, please increase the QPS and Burst values in the "configmap" section:
+```bash
+   clientConnection:
+      burst: 200
+      qps: 100
+```
+An example of throttle error from the pod logs:
+```bash
+I1030 23:19:48.258159       1 request.go:697] Waited for 1.93509847s due to client-side throttling, not priority and fairness, request: POST:https://10.100.0.1:443/apis/events.k8s.io/v1/namespa...vents
+I1030 23:19:58.258457       1 request.go:697] Waited for 1.905177346s due to client-side throttling, not priority and fairness, request: POST:https://10.100.0.1:443/apis/events.k8s.io/v1/namespa...
+```
 
 Run the following command against **EKS v1.28**:
 
@@ -298,6 +308,9 @@ data:
       leaderElect: true
       resourceNamespace: kube-system
       resourceName: my-scheduler
+    clientConnection:
+      burst: 200
+      qps: 100
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
*Issue #, if available:*

An example of throttle error from the pod logs:
```bash
I1030 23:19:48.258159       1 request.go:697] Waited for 1.93509847s due to client-side throttling, not priority and fairness, request: POST:https://10.100.0.1:443/apis/events.k8s.io/v1/namespa...vents
I1030 23:19:58.258457       1 request.go:697] Waited for 1.905177346s due to client-side throttling, not priority and fairness, request: POST:https://10.100.0.1:443/apis/events.k8s.io/v1/namespa...
```
*Description of changes:*
add the adjustable QPS and Burst attributes in the "configmap" section:
```bash
   clientConnection:
      burst: 200
      qps: 100
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
