### PR TITLE
Fix executor container name in pod template example

### DIFF
--- a/content/security/docs/spark/secrets.md
+++ b/content/security/docs/spark/secrets.md
@@ -82,7 +82,7 @@ kind: Pod
 
 spec:
   containers:
-    - name: spark-kubernetes-executors
+    - name: spark-kubernetes-executor
       volumeMounts:
         - mountPath: "/var/secrets"
           name: mysql-cred


### PR DESCRIPTION
According to Spark Kubernetes naming conventions, the container name for executors in a pod template is spark-kubernetes-executor (singular). The current documentation incorrectly uses spark-kubernetes-executors (plural), which Spark treats as a custom container requiring an explicit image.

This change updates the pod template example to use the correct container name, ensuring it merges correctly with Spark-generated pod specifications. See upstream Spark docs for reference: https://spark.apache.org/docs/latest/running-on-kubernetes.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.